### PR TITLE
fix documentation generation with doxygen-1.8.16

### DIFF
--- a/doxygen.in
+++ b/doxygen.in
@@ -763,7 +763,7 @@ INPUT_ENCODING         = UTF-8
 # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
 # *.qsf, *.as and *.js.
 
-FILE_PATTERNS          =
+#FILE_PATTERNS          =
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.


### PR DESCRIPTION
This fixes a known bug in doxygen-1.8.16 (see issue 7190), which
fails to generate any documentation whenever FILE_PATTERNS is set to
empty, without printing any warnings or errors.